### PR TITLE
Feature/378728 move temp claim creation to endemics index

### DIFF
--- a/app/routes/endemics/index.js
+++ b/app/routes/endemics/index.js
@@ -16,8 +16,15 @@ const {
   endemicsWhichTypeOfReview
 } = require('../../config/routes')
 const {
-  endemicsClaim: { landingPage: landingPageKey, latestEndemicsApplication: latestEndemicsApplicationKey, latestVetVisitApplication: latestVetVisitApplicationKey, previousClaims: previousClaimsKey }
+  endemicsClaim: {
+    landingPage: landingPageKey,
+    latestEndemicsApplication: latestEndemicsApplicationKey,
+    latestVetVisitApplication: latestVetVisitApplicationKey,
+    previousClaims: previousClaimsKey,
+    reference: referenceKey
+  }
 } = require('../../session/keys')
+const createClaimReference = require('../../lib/create-temp-claim-reference')
 
 const endemicsWhichTypeOfReviewURI = `${urlPrefix}/${endemicsWhichTypeOfReview}`
 const endemicsWhichSpeciesURI = `${urlPrefix}/${endemicsWhichSpecies}`
@@ -39,9 +46,11 @@ module.exports = {
         const claims = await getClaimsByApplicationReference(
           latestEndemicsApplication.reference
         )
+        const tempClaimId = createClaimReference()
         session.setEndemicsClaim(request, latestVetVisitApplicationKey, latestVetVisitApplication)
         session.setEndemicsClaim(request, latestEndemicsApplicationKey, latestEndemicsApplication)
         session.setEndemicsClaim(request, previousClaimsKey, claims)
+        session.setEndemicsClaim(request, referenceKey, tempClaimId)
 
         // new user
         if ((!Array.isArray(claims) || !claims?.length) && latestVetVisitApplication === undefined) {

--- a/app/routes/signin-oidc.js
+++ b/app/routes/signin-oidc.js
@@ -10,7 +10,7 @@ const { NoApplicationFoundError, InvalidPermissionsError, ClaimHasAlreadyBeenMad
 const { raiseIneligibilityEvent } = require('../event')
 const { changeContactHistory } = require('../api-requests/contact-history-api')
 const appInsights = require('applicationinsights')
-const createClaimReference = require('../lib/create-temp-claim-reference')
+// const createClaimReference = require('../lib/create-temp-claim-reference')
 
 const endemicsEnabled = config.endemics.enabled
 
@@ -64,7 +64,6 @@ module.exports = [{
         )
 
         if (endemicsEnabled) {
-          const tempClaimId = createClaimReference()
           session.setEndemicsClaim(
             request,
             sessionKeys.endemicsClaim.organisation,
@@ -79,7 +78,6 @@ module.exports = [{
               frn: organisationSummary.organisation.businessReference
             }
           )
-          session.setEndemicsClaim(request, sessionKeys.endemicsClaim.reference, tempClaimId)
         }
 
         if (!organisationSummary.organisationPermission) {

--- a/app/routes/signin-oidc.js
+++ b/app/routes/signin-oidc.js
@@ -10,7 +10,6 @@ const { NoApplicationFoundError, InvalidPermissionsError, ClaimHasAlreadyBeenMad
 const { raiseIneligibilityEvent } = require('../event')
 const { changeContactHistory } = require('../api-requests/contact-history-api')
 const appInsights = require('applicationinsights')
-// const createClaimReference = require('../lib/create-temp-claim-reference')
 
 const endemicsEnabled = config.endemics.enabled
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ffc-ahwr-farmer-claim",
-  "version": "0.37.57",
+  "version": "0.37.58",
   "description": "Web frontend for farmer claim journey",
   "homepage": "https://github.com/DEFRA/ffc-ahwr-farmer-claim",
   "main": "app/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ffc-ahwr-farmer-claim",
-  "version": "0.37.58",
+  "version": "0.37.59",
   "description": "Web frontend for farmer claim journey",
   "homepage": "https://github.com/DEFRA/ffc-ahwr-farmer-claim",
   "main": "app/index.js",


### PR DESCRIPTION
## Description of changes
Moved temp claim reference creation to endemics/index to allow for sign-in via dashboard
<!-- What have you implemented in this PR? -->

## Checklist

<!-- [x] if you have completed the task -->
<!-- [n/a] if the task is not relevant -->

- [ ] Content has no typos
- [ ] Correct inline validation errors
- [ ] Back link and next page navigation
- [ ] Removed all unnecessary console logs
- [ ] Removed all commented out code
- [ ] Updated README / confluence
