### PR TITLE
AHWR-80: Amending what is feature flagged and what isnt for PI hunt guidance

### DIFF
--- a/app/views/endemics/number-of-species-exception.njk
+++ b/app/views/endemics/number-of-species-exception.njk
@@ -20,19 +20,32 @@
       <h2 class="govuk-heading-m">What to do next</h2>
       <p class="govuk-body">If samples were not taken from the minimum required number of animals, they need to be taken again from the minimum number.</p>
       <p class="govuk-body">The number required for each species is included in the guidance:</p>
+
+      {% if piHuntEnabled == false %}
+      <ul class="govuk-list govuk-list--bullet">
+        <li>
+          <a class="govuk-link" rel="external" href="https://www.gov.uk/government/publications/cattle-testing-required-for-an-animal-health-and-welfare-review-and-endemic-disease-follow-up/vets-testing-cattle-for-animal-health-and-welfare-review#testing-sampling-and-advice">Testing cattle for animal health and welfare review</a>
+        </li>
+        <li>
+          <a class="govuk-link" rel="external" href="https://www.gov.uk/government/publications/cattle-testing-required-for-an-animal-health-and-welfare-review-and-endemic-disease-follow-up/vets-testing-beef-cattle-for-endemic-disease-follow-up#testing-sampling-and-advice">Testing beef cattle for endemic disease follow-up</a>
+        </li>
+        <li>
+          <a class="govuk-link" rel="external" href="https://www.gov.uk/government/publications/pigs-testing-required-for-an-annual-health-and-welfare-review-and-endemic-disease-follow-up/vets-testing-pigs-for-animal-health-and-welfare-review#testing-sampling-and-advice">Testing pigs for animal health and welfare review</a>
+        </li>
+      </ul>
+      {% endif %}
+
+      {% if piHuntEnabled == true %}
       <ul class="govuk-list govuk-list--bullet">
         <li>
           <a class="govuk-link" rel="external" href="https://www.gov.uk/guidance/farmers-and-vets-what-happens-on-an-animal-health-and-welfare-review#during-the-review-sampling-for-disease-testing">Testing beef cattle for animal health and welfare review</a>
         </li>
-        {% if piHuntEnabled == false %}
-          <li>
-            <a class="govuk-link" rel="external" href="https://www.gov.uk/government/publications/cattle-testing-required-for-an-animal-health-and-welfare-review-and-endemic-disease-follow-up/vets-testing-beef-cattle-for-endemic-disease-follow-up#testing-sampling-and-advice">Testing beef cattle for endemic disease follow-up</a>
-          </li>
-        {% endif %}
         <li>
           <a class="govuk-link" rel="external" href="https://www.gov.uk/guidance/farmers-and-vets-what-happens-on-an-animal-health-and-welfare-review#during-the-review-sampling-for-disease-testing">Testing pigs for animal health and welfare review</a>
         </li>
       </ul>
+      {% endif %}
+      
       <p class="govuk-body">When samples have been taken from the required number, start your claim again</p>
       <p class="govuk-body">If you have entered the wrong number, you'll need to go back and enter the correct number.</p>
       <p class="govuk-body">

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ffc-ahwr-farmer-claim",
-  "version": "0.38.59",
+  "version": "0.38.60",
   "description": "Web frontend for farmer claim journey",
   "homepage": "https://github.com/DEFRA/ffc-ahwr-farmer-claim",
   "main": "app/index.js",


### PR DESCRIPTION
## Description of changes

Instead of just feature flagging one bullet point on the error page, we are instead feature flagging the entire section of bullet points, so that if we turn off PI hunt, the guidance will revert back to the initial guidance.

