### PR TITLE
AHWR-80: Spelling mistake on error page

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,0 @@
-## Description of changes
-
-<!-- What have you implemented in this PR? -->
-

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,14 +2,3 @@
 
 <!-- What have you implemented in this PR? -->
 
-## Checklist
-
-<!-- [x] if you have completed the task -->
-<!-- [n/a] if the task is not relevant -->
-
-- [ ] Content has no typos
-- [ ] Correct inline validation errors
-- [ ] Back link and next page navigation
-- [ ] Removed all unnecessary console logs
-- [ ] Removed all commented out code
-- [ ] Updated README / confluence

--- a/app/views/endemics/number-of-species-pigs-exception.njk
+++ b/app/views/endemics/number-of-species-pigs-exception.njk
@@ -20,7 +20,7 @@
       <h2 class="govuk-heading-m">What to do next</h2>
       <p class="govuk-body">If samples were not taken from the number of pigs required, they need to be taken again from the required number.</p>
       <p class="govuk-body">
-        <a class="govuk-link" rel="external" href="https://www.gov.uk/government/publications/pigs-testing-required-for-an-annual-health-and-welfare-review-and-endemic-disease-follow-up/vets-testing-pigs-for-endemic-disease-follow-up#testing-sampling-and-advice">The minimum number of pigs that needs to be sampled is in the guidance.</a>
+        <a class="govuk-link" rel="external" href="https://www.gov.uk/government/publications/pigs-testing-required-for-an-annual-health-and-welfare-review-and-endemic-disease-follow-up/vets-testing-pigs-for-endemic-disease-follow-up#testing-sampling-and-advice">The minimum number of pigs that need to be sampled is in the guidance.</a>
       </p>
       <p class="govuk-body">When samples have been taken from the required number of pigs, start your claim again</p>
       <p class="govuk-body">If you entered the wrong number, you'll need to go back and enter the correct number.</p>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ffc-ahwr-farmer-claim",
-  "version": "0.38.60",
+  "version": "0.38.61",
   "description": "Web frontend for farmer claim journey",
   "homepage": "https://github.com/DEFRA/ffc-ahwr-farmer-claim",
   "main": "app/index.js",


### PR DESCRIPTION
## Description of changes

Correcting a spelling/grammatical error on the error page for pigs. Also removing checklist from the PR template.