### PR TITLE
AHWR-80: Made bullet points in exception view lower case

### DIFF
--- a/app/views/endemics/number-of-species-exception.njk
+++ b/app/views/endemics/number-of-species-exception.njk
@@ -38,10 +38,10 @@
       {% if piHuntEnabled == true %}
       <ul class="govuk-list govuk-list--bullet">
         <li>
-          <a class="govuk-link" rel="external" href="https://www.gov.uk/guidance/farmers-and-vets-what-happens-on-an-animal-health-and-welfare-review#during-the-review-sampling-for-disease-testing">Testing beef cattle for animal health and welfare review</a>
+          <a class="govuk-link" rel="external" href="https://www.gov.uk/guidance/farmers-and-vets-what-happens-on-an-animal-health-and-welfare-review#during-the-review-sampling-for-disease-testing">testing beef cattle for animal health and welfare review</a>
         </li>
         <li>
-          <a class="govuk-link" rel="external" href="https://www.gov.uk/guidance/farmers-and-vets-what-happens-on-an-animal-health-and-welfare-review#during-the-review-sampling-for-disease-testing">Testing pigs for animal health and welfare review</a>
+          <a class="govuk-link" rel="external" href="https://www.gov.uk/guidance/farmers-and-vets-what-happens-on-an-animal-health-and-welfare-review#during-the-review-sampling-for-disease-testing">testing pigs for animal health and welfare review</a>
         </li>
       </ul>
       {% endif %}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ffc-ahwr-farmer-claim",
-  "version": "0.38.63",
+  "version": "0.38.64",
   "description": "Web frontend for farmer claim journey",
   "homepage": "https://github.com/DEFRA/ffc-ahwr-farmer-claim",
   "main": "app/index.js",


### PR DESCRIPTION
Bullet points in exception view were in start case - moved them to lower case.